### PR TITLE
Limit the load of instagram-feed.js to essays and pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Use the "Insert custom code" if you're adding it to a Koken page.
 
 Please feel free to contribute to the code.
 
+* **Jonathan Rousseaux** - *Update: limit load of instagram-feed.js to essays and pages* - [JR-Photo.be](https://www.jr-photo.be)
+
 ## Authors
 
 * **Emin Jasarevic** - *Initial work* - [Soonce](https://www.soonce.com/en)

--- a/plugin.php
+++ b/plugin.php
@@ -4,10 +4,12 @@ class EminosInstagramFeed extends KokenPlugin
 {
     public function __construct()
     {
+        $url = $_SERVER['REQUEST_URI'];
+        if ((strpos($url,'essays')  !== false) || (strpos($url,'pages')  !== false)) {
         $this->register_hook('before_closing_head', 'add_head');
         $this->register_hook('before_closing_body', 'add_body');
+        }
     }
-
     public function add_head()
     {
         echo '<link rel="stylesheet" href="' . $this->get_path() . '/dist/instagram-feed.css"/>';


### PR DESCRIPTION
Small update to limit the load of the plugin to pages and essays to avoid loading it on pages where the plugin is not useful.
There may be a native koken fonction to detect text page but I haven't found it.